### PR TITLE
Fix CSP header for fonts

### DIFF
--- a/web/backlog.php
+++ b/web/backlog.php
@@ -59,7 +59,7 @@ $cspPolicy = "default-src 'self'; "
     . "img-src 'self'; "
     . "media-src 'none'; "
     . "frame-src 'none'; "
-    . "font-src 'self' https://themes.googleusercontent.com; "
+    . "font-src 'self' https://themes.googleusercontent.com https://fonts.gstatic.com; "
     . "connect-src 'self'";
 
 header('Content-Security-Policy: ' . $cspPolicy);


### PR DESCRIPTION
Some of the fonts are redirected to/served from fonts.gstatic.com instead of themes.googleusercontent.com. This caused the fonts used to not show correctly on browsers enforcing CSP. This change makes sure the fonts can be loaded properly.
